### PR TITLE
feat(booking api): add REST API endpoints for booking

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -5443,6 +5443,24 @@
         "uuid": "^3.1.0"
       }
     },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "^4.13.1"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
+      }
+    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -5827,6 +5845,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -6120,6 +6143,14 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
+      }
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
       }
     },
     "ultron": {
@@ -6472,27 +6503,8 @@
       "integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "websocket": {
-          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "requires": {
-            "debug": "^2.2.0",
-            "nan": "^2.3.3",
-            "typedarray-to-buffer": "^3.1.2",
-            "yaeti": "^0.0.6"
-          }
-        }
+        "web3-core-helpers": "1.0.0-beta.34",
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       }
     },
     "web3-shh": {
@@ -6524,6 +6536,26 @@
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        }
+      }
+    },
+    "websocket": {
+      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+      "requires": {
+        "debug": "^2.2.0",
+        "nan": "^2.3.3",
+        "typedarray-to-buffer": "^3.1.2",
+        "yaeti": "^0.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -6617,6 +6649,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -27,6 +27,8 @@
     "express-rate-limit": "^2.11.0",
     "mailgun-js": "^0.20.0",
     "mongoose": "^5.2.4",
+    "request": "^2.87.0",
+    "request-promise-native": "^1.0.5",
     "web3": "^1.0.0-beta.34"
   },
   "devDependencies": {

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -11,19 +11,6 @@ const app = express();
 app.use(bodyParser.json());
 app.use('/*', validateIPWhiteList);
 
-// Error handler
-app.use((err, req, res) => {
-  if (!err.code) {
-    err = handleApplicationError('genericError', err);
-  }
-  res.status(err.status).json({
-    status: err.status,
-    code: err.code,
-    short: err.short,
-    long: err.long,
-  });
-});
-
 // Root handler
 app.get('/', (req, res) => {
   const response = {
@@ -41,6 +28,19 @@ app.use('*', (req, res) => {
     code: '#notFound',
     short: 'Page not found',
     long: 'This endpoint does not exist',
+  });
+});
+
+// Error handler
+app.use((err, req, res, next) => {
+  if (!err.code) {
+    err = handleApplicationError('genericError', err);
+  }
+  res.status(err.status).json({
+    status: err.status,
+    code: err.code,
+    short: err.short,
+    long: err.long,
   });
 });
 

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -4,8 +4,8 @@ const bodyParser = require('body-parser');
 const { validateIPWhiteList } = require('./middlewares/ip-white-list');
 const { handleApplicationError } = require('./errors');
 const { version } = require('../package.json');
-
 require('./models');
+const routes = require('./routes');
 
 const app = express();
 app.use(bodyParser.json());
@@ -20,6 +20,9 @@ app.get('/', (req, res) => {
   };
   res.status(200).json(response);
 });
+
+// API routes
+app.use('/api', routes);
 
 // 404 handler
 app.use('*', (req, res) => {

--- a/server/src/errors/codes.js
+++ b/server/src/errors/codes.js
@@ -32,17 +32,17 @@ module.exports = {
   noPaymentAmount: {
     status: 409,
     short: 'No payment amount provided.',
-    long: 'The payment.amount is required.',
+    long: 'The paymentAmount is required.',
   },
   noPaymentType: {
     status: 409,
     short: 'No payment type provided.',
-    long: 'The payment.type is required.',
+    long: 'The paymentType is required.',
   },
   noPaymentTx: {
     status: 409,
     short: 'No payment tx provided.',
-    long: 'The payment.tx is required.',
+    long: 'The paymentTx is required.',
   },
   noSignatureTimestamp: {
     status: 409,
@@ -53,5 +53,10 @@ module.exports = {
     status: 409,
     short: 'No personal information provided.',
     long: 'The personalInfo is required.',
+  },
+  duplicateBooking: {
+    status: 409,
+    short: 'Duplicate booking.',
+    long: 'Only one booking per guest eth address is allowed.',
   },
 };

--- a/server/src/middlewares/ip-white-list.js
+++ b/server/src/middlewares/ip-white-list.js
@@ -1,7 +1,7 @@
 const { handleApplicationError } = require('../errors');
 
 const validateIPWhiteList = function (req, res, next) {
-  const whiteList = process.env.WHITELIST.split('1');
+  const whiteList = process.env.WHITELIST.split(',');
   if (!whiteList.length) {
     return next();
   }
@@ -10,7 +10,6 @@ const validateIPWhiteList = function (req, res, next) {
             req.connection.remoteAddress ||
             req.socket.remoteAddress ||
             req.connection.socket.remoteAddress;
-
   if (ip.substr(0, 7) === '::ffff:') {
     ip = ip.substr(7);
   }

--- a/server/src/routes/index.js
+++ b/server/src/routes/index.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const { Booking } = require('../controllers/Booking');
+
+const router = express.Router();
+const bookingUrl = '/booking';
+
+router.post(`${bookingUrl}`, async (req, res, next) => {
+  try {
+    const booking = await Booking.create(req.body);
+    res.json(booking.toPlainObject());
+  } catch (e) {
+    return next(e);
+  }
+});
+
+router.get(`${bookingUrl}/:id`, async (req, res, next) => {
+  try {
+    const booking = await Booking.read({ id: req.params.id });
+    if (!booking) return next();
+    res.json(booking.toPlainObject());
+  } catch (e) {
+    return next(e);
+  }
+});
+
+router.delete(`${bookingUrl}/:id`, async (req, res, next) => {
+  try {
+    const booking = await Booking.read({ id: req.params.id });
+    await booking.delete();
+    res.json({ id: req.params.id });
+  } catch (e) {
+    return next(e);
+  }
+});
+
+module.exports = router;

--- a/server/src/utils/classHelper.js
+++ b/server/src/utils/classHelper.js
@@ -1,0 +1,23 @@
+/**
+ * Returns the instance as a plain object filled with the getters
+ */
+function toPlainObject (instance) {
+  const prototype = Object.getPrototypeOf(instance);
+  const prototypeNames = Object.getOwnPropertyNames(prototype);
+  const props = Object.getOwnPropertyNames(instance);
+  const plainObject = {};
+  // fill the plain object with the value of the getters
+  prototypeNames.forEach(property => {
+    if (Object.getOwnPropertyDescriptor(prototype, property).get) plainObject[property] = instance[property];
+  });
+  // fill the plain object with the public variables
+  for (const prop of props) {
+    if (prop.match(/^_/)) {
+      continue;
+    }
+    plainObject[prop] = instance[prop];
+  }
+  return plainObject;
+}
+
+module.exports = { toPlainObject };

--- a/server/test/routes/index.spec.js
+++ b/server/test/routes/index.spec.js
@@ -1,0 +1,95 @@
+/* eslint-env mocha */
+require('dotenv').config({ path: './test/utils/.env' });
+const { expect } = require('chai');
+const mongoose = require('mongoose');
+const request = require('request-promise-native');
+
+const { validBooking, validBookingDB } = require('../utils/test-data');
+const apiUrl = `http://localhost:${process.env.SERVER_PORT}/api`;
+let server;
+let BookingModel;
+describe('Booking API', () => {
+  before(async () => {
+    server = await require('../../src/index.js');
+    BookingModel = mongoose.model('Booking');
+  });
+
+  afterEach(async function () {
+    await BookingModel.remove({}).exec();
+  });
+
+  after(async () => {
+    await server.close();
+    await mongoose.connection.close();
+  });
+
+  describe('POST /api/booking', () => {
+    it('Should create a valid booking', async () => {
+      const body = validBooking;
+      const booking = await request({ url: `${apiUrl}/booking`, method: 'POST', json: true, body });
+      expect(booking).to.have.property('id');
+      expect(booking).to.have.property('publicKey', validBooking.publicKey);
+      expect(booking).to.have.property('guestEthAddress', validBooking.guestEthAddress);
+      expect(booking).to.have.property('paymentAmount', validBooking.paymentAmount);
+      expect(booking).to.have.property('paymentType', validBooking.paymentType);
+      expect(booking).to.have.property('signatureTimestamp');
+      expect(booking.signatureTimestamp).to.have.a('number');
+      expect(booking).to.have.property('personalInfo');
+      expect(booking.personalInfo).to.have.property('name', validBooking.personalInfo.name);
+      expect(booking.personalInfo).to.have.property('email', validBooking.personalInfo.email);
+      expect(booking.personalInfo).to.have.property('birthday', validBooking.personalInfo.birthday);
+      expect(booking.personalInfo).to.have.property('phone', validBooking.personalInfo.phone);
+    });
+    it('Should propagate data errors', async () => {
+      const body = Object.assign({}, validBooking, { paymentAmount: 0 });
+
+      try {
+        await request({ url: `${apiUrl}/booking`, method: 'POST', json: true, body });
+        throw new Error('should not be called');
+      } catch (e) {
+        expect(e).to.have.property('error');
+        expect(e.error).to.have.property('code', '#minAmount');
+      }
+    });
+  });
+
+  describe('GET /api/booking/:id', () => {
+    it('Should read a booking', async () => {
+      const dbBooking = new BookingModel(validBookingDB);
+      await dbBooking.save();
+      const booking = await request({ url: `${apiUrl}/booking/${dbBooking.id}`, method: 'GET', json: true });
+      expect(booking).to.have.property('id');
+      expect(booking).to.have.property('publicKey', validBooking.publicKey);
+      expect(booking).to.have.property('guestEthAddress', validBooking.guestEthAddress);
+      expect(booking).to.have.property('paymentAmount', validBooking.paymentAmount);
+      expect(booking).to.have.property('paymentType', validBooking.paymentType);
+      expect(booking).to.have.property('signatureTimestamp');
+      expect(booking.signatureTimestamp).to.have.a('number');
+      expect(booking).to.have.property('personalInfo');
+      expect(booking.personalInfo).to.have.property('name', validBooking.personalInfo.name);
+      expect(booking.personalInfo).to.have.property('email', validBooking.personalInfo.email);
+      expect(booking.personalInfo).to.have.property('birthday', validBooking.personalInfo.birthday);
+      expect(booking.personalInfo).to.have.property('phone', validBooking.personalInfo.phone);
+    });
+    it('Should propagate data errors', async () => {
+      try {
+        await request({ url: `${apiUrl}/booking/some-invalid-id`, method: 'GET', json: true });
+        throw new Error('should not be called');
+      } catch (e) {
+        expect(e).to.have.property('error');
+        expect(e.error).to.have.property('code', '#notFound');
+      }
+    });
+  });
+
+  describe('DELETE /api/booking/:id', () => {
+    it('Should delete a booking', async () => {
+      const dbBooking = new BookingModel(validBookingDB);
+      await dbBooking.save();
+      const booking = await request({ url: `${apiUrl}/booking/${dbBooking.id}`, method: 'DELETE', json: true });
+      const dbReadBooking = await BookingModel.findById(booking.id).exec();
+      expect(booking).to.have.property('id', dbBooking.id);
+      expect(dbReadBooking).to.be.an.equal(null);
+    });
+  });
+});

--- a/server/test/utils/classHelper.spec.js
+++ b/server/test/utils/classHelper.spec.js
@@ -1,0 +1,24 @@
+/* eslint-env mocha */
+const { expect } = require('chai');
+const { toPlainObject } = require('../../src/utils/classHelper');
+const { ToPlainObjectTestClass } = require('./test-data');
+
+const instance = new ToPlainObjectTestClass();
+const plainObject = toPlainObject(instance);
+
+describe('Class helper', () => {
+  describe('toPlainObject', () => {
+    it('Should return a plain object of a class', () => {
+      expect(plainObject).to.not.be.an.instanceof(ToPlainObjectTestClass);
+    });
+    it('Should contain getters as properties', () => {
+      expect(plainObject).to.have.property('email', instance.email);
+    });
+    it('Should avoid private props', () => {
+      expect(plainObject).to.not.have.property('_email');
+    });
+    it('Should avoid methods', () => {
+      expect(plainObject).to.not.have.property('save');
+    });
+  });
+});

--- a/server/test/utils/test-data.js
+++ b/server/test/utils/test-data.js
@@ -85,9 +85,21 @@ background-color: #f6f6f6;
 `;
 
   return testHtml;
-}
+};
 
+class ToPlainObjectTestClass {
+  constructor () {
+    this.name = 'some name';
+    this._email = 'some@email.com';
+  }
+  get email () {
+    return this._email;
+  }
+  save () {
+  }
+}
 
 module.exports = {
   testHtmlBody,
+  ToPlainObjectTestClass,
 };


### PR DESCRIPTION
I added the following endpoints:

```javascript
url: POST /api/booking
params: 
{
  publicKey: String,
  guestEthAddress: String,
  paymentAmount: Number (greater than 0)
  paymentType: String (eth or lif)
  personalInfo: Object
}
ie response:
{
    "paymentType": "eth",
    "paymentAmount": 0.1,
    "signatureTimestamp": 1532346369,
    "personalInfo": {
        "email": "some@email.com"
    },
    "id": "5b55c70950c83b29bd42f184",
    "publicKey": "some public key",
    "guestEthAddress": "0xe91036d59eAd8b654eE2F5b354245f6D7eD2487e12"
}
```

```
url: GET /api/booking/:id
ie response:
{
    "paymentType": "eth",
    "paymentAmount": 0.1,
    "signatureTimestamp": 1532346369,
    "personalInfo": {
        "email": "some@email.com"
    },
    "id": "5b55c70950c83b29bd42f184",
    "publicKey": "some public key",
    "guestEthAddress": "0xe91036d59eAd8b654eE2F5b354245f6D7eD2487e12"
}
```
```javascript
url: DELETE /api/booking/:id
ie response:
{
    "id": "5b55c70950c83b29bd42f184"
}
```
Also, I added a the function `toPlainObject` to the controller that returns a plain object of an instance .
I needed to do this to return the getters as object keys.

For now, we are allowing only one booking per guest eth address, we should consider allowing multiple bookings per address.