### PR TITLE
Feat/pull by booking hash

### DIFF
--- a/server/src/controllers/Booking.js
+++ b/server/src/controllers/Booking.js
@@ -36,6 +36,13 @@ async function readBooking (filter) {
     booking.personalInfo = bookingModel.decryptPersonalInfo();
     return booking;
   }
+  if (filter.bookingHash) {
+    const bookingModel = await BookingModel.findOne({ bookingHash: filter.bookingHash }).exec();
+    if (!bookingModel) return null;
+    const booking = bookingModel.toObject();
+    booking.personalInfo = bookingModel.decryptPersonalInfo();
+    return booking;
+  }
   return null;
 }
 

--- a/server/src/routes/index.js
+++ b/server/src/routes/index.js
@@ -26,9 +26,9 @@ router.post(`${bookingUrl}`, async (req, res, next) => {
   }
 });
 
-router.get(`${bookingUrl}/:id`, async (req, res, next) => {
+router.get(`${bookingUrl}/:bookingHash`, async (req, res, next) => {
   try {
-    const booking = await readBooking({ id: req.params.id });
+    const booking = await readBooking({ bookingHash: req.params.bookingHash });
     if (!booking) return next();
     res.json(booking);
   } catch (e) {

--- a/server/test/controllers/Booking.spec.js
+++ b/server/test/controllers/Booking.spec.js
@@ -55,10 +55,32 @@ describe('Booking controller', () => {
     }
   });
 
-  it('Should read a booking', async () => {
+  it('Should read a booking using id', async () => {
     const dbBooking = BookingModel.generate(validBookingWithEthPrice);
     await dbBooking.save();
     const booking = await readBooking({ id: dbBooking._id });
+    expect(booking).to.have.property('_id');
+    expect(booking).to.have.property('bookingHash');
+    expect(booking.bookingHash).to.be.a('string');
+    expect(booking).to.have.property('guestEthAddress', validBookingWithEthPrice.guestEthAddress);
+    expect(booking).to.have.property('paymentAmount');
+    expect(booking).to.have.property('paymentType', validBookingWithEthPrice.paymentType);
+    expect(booking).to.have.property('signatureTimestamp');
+    expect(booking.signatureTimestamp).to.have.a('number');
+    expect(booking).to.have.property('personalInfo');
+    expect(booking.personalInfo).to.have.property('name', validBookingWithEthPrice.personalInfo.name);
+    expect(booking.personalInfo).to.have.property('email', validBookingWithEthPrice.personalInfo.email);
+    expect(booking.personalInfo).to.have.property('birthday', validBookingWithEthPrice.personalInfo.birthday);
+    expect(booking.personalInfo).to.have.property('phone', validBookingWithEthPrice.personalInfo.phone);
+    expect(booking).to.have.property('roomType', validBookingWithEthPrice.roomType);
+    expect(booking).to.have.property('to', validBookingWithEthPrice.to);
+    expect(booking).to.have.property('from', validBookingWithEthPrice.from);
+  });
+
+  it('Should read a booking using bookingHash', async () => {
+    const dbBooking = BookingModel.generate(validBookingWithEthPrice);
+    await dbBooking.save();
+    const booking = await readBooking({ bookingHash: dbBooking.bookingHash });
     expect(booking).to.have.property('_id');
     expect(booking).to.have.property('bookingHash');
     expect(booking.bookingHash).to.be.a('string');

--- a/server/test/routes/index.spec.js
+++ b/server/test/routes/index.spec.js
@@ -51,11 +51,11 @@ describe('Booking API', () => {
     });
   });
 
-  describe('GET /api/booking/:id', () => {
+  describe('GET /api/booking/:bookingHash', () => {
     it('Should read a booking', async () => {
       const dbBooking = BookingModel.generate(validBookingWithEthPrice);
       await dbBooking.save();
-      const booking = await request({ url: `${apiUrl}/booking/${dbBooking.id}`, method: 'GET', json: true });
+      const booking = await request({ url: `${apiUrl}/booking/${dbBooking.bookingHash}`, method: 'GET', json: true });
       expect(booking).to.have.property('_id');
       expect(booking).to.have.property('bookingHash');
       expect(booking).to.have.property('guestEthAddress', validBooking.guestEthAddress);


### PR DESCRIPTION
I added the ability to pull bookings by `bookingHash`. Also, I replaced the endpoint GET `/booking/:id` with `/booking/:bookingHash` since we are no longer using `id` to get bookings from FE